### PR TITLE
Hotfix: 채팅메시지 시간 서울기준으로

### DIFF
--- a/src/main/java/com/hanghae/baedalfriend/chat/controller/ChattingController.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/controller/ChattingController.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
 
 @Slf4j
 @RestController
@@ -22,6 +26,13 @@ public class ChattingController {
     //pub/chat/message/ 에서 들어오는 메시지 처리
     @MessageMapping("/chat/message")
     public void message(ChatMessageRequestDto messageRequestDto) {
+        // 메시지 생성 시간 정보
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("YYYY-MM-DD");
+        Calendar calendar = Calendar.getInstance();
+        Date date = calendar.getTime();
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
+        String dateOutput = simpleDateFormat.format(date);
+        messageRequestDto.setCreatedAt(dateOutput);
 
         ChatMessage chatMessage = new ChatMessage(messageRequestDto);
 

--- a/src/main/java/com/hanghae/baedalfriend/chat/dto/request/ChatMessageRequestDto.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/dto/request/ChatMessageRequestDto.java
@@ -1,8 +1,11 @@
 package com.hanghae.baedalfriend.chat.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hanghae.baedalfriend.chat.entity.ChatMessage;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -11,4 +14,5 @@ public class ChatMessageRequestDto {
     private Long roomId;
     private String message;
     private String sender;
+    private String createdAt;
 }

--- a/src/main/java/com/hanghae/baedalfriend/chat/entity/ChatMessage.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/entity/ChatMessage.java
@@ -46,6 +46,8 @@ public class ChatMessage extends Timestamped  implements Serializable  {
     @ManyToOne
     private Member member;
 
+    private String createdAt;
+
 
 
 

--- a/src/main/java/com/hanghae/baedalfriend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/service/ChatRoomService.java
@@ -110,6 +110,7 @@ public class ChatRoomService {
                         .build();
                 chatRoomMemberJpaRepository.save(chatRoomMember);
 
+
                 return ResponseDto.success("채팅방입장");
 
         } else {
@@ -147,22 +148,9 @@ public class ChatRoomService {
 
         // 나간 유저를 채팅방 리스트에서 제거
         chatRoomMemberJpaRepository.deleteByMember(member);
-        // 현재 채팅룸에 한명이라도 남아있다면 퇴장메시지 전송
-        if (chatRoomMemberJpaRepository.findAllByChatRoom(chatRoom).size() == 0) {
-            chatService.sendChatMessage(
-                    ChatMessage.builder()
-                            .type(ChatMessage.MessageType.QUIT)
-                            .roomId(roomId)
-                            .sender(member.getNickname())
-                            .member(member)
-                            .build()
-            );
-            return ResponseDto.success("퇴장메시지 전송 성공");
 
-        } else {
-            return ResponseDto.success("채팅방안 사람이 없음");
+            return ResponseDto.success("퇴장성공");
 
-        }
 
     }
 

--- a/src/main/java/com/hanghae/baedalfriend/chat/service/ChatService.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/service/ChatService.java
@@ -55,6 +55,7 @@ public class ChatService {
         message.setRoomId(chatMessage.getRoomId());
         message.setSender(chatMessage.getSender());
         message.setMember(member);
+        message.setCreatedAt(chatMessage.getCreatedAt());
 
 
         chatMessageRepository.save(message);

--- a/src/main/java/com/hanghae/baedalfriend/service/KakaoMemberService.java
+++ b/src/main/java/com/hanghae/baedalfriend/service/KakaoMemberService.java
@@ -33,6 +33,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j


### PR DESCRIPTION
### PR 타입
오류해결

### 반영 브랜치
chatting3 -> dev

### 변경 사항
채팅 시간이 태평양기준으로 저장이 돼서 대한민국시간 기준으로 저장되게 로직 수정 했습니다