### PR TITLE
Fix Keyword 최근검색어 조회시 최근 등록순 7개 까지 조회되도록 수정

### DIFF
--- a/src/main/java/com/hanghae/baedalfriend/service/KeywordService.java
+++ b/src/main/java/com/hanghae/baedalfriend/service/KeywordService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Component
@@ -77,8 +78,8 @@ public class KeywordService {
         // 회원 유효성 검사
         Member member = validateMember(request);
 
-        //유저가 등록한 최근 검색어
-        List<Keyword> keywordList = keywordRepository.findAllByMemberIdOrderByCreatedAtDesc(member.getId());
+        // 최근 등록순 7개만 조회
+         List<Keyword> keywordList = keywordRepository.findAllByMemberIdOrderByCreatedAtDesc(member.getId()).stream().limit(7).collect(Collectors.toList());
         return ResponseDto.success(keywordList);
     }
 


### PR DESCRIPTION
###이슈 내용
최근 검색어 조회시 유가 검색한 검색어 내용 전체가 조회 됨

반영 브랜치
keyword -> dev

변경 사항
최근검색어 조회시 최근 등록순 7개 까지만 조회 할 수 있도록 코드 수정