### PR TITLE
Fix: soft delete 기능을 뺐습니다

### DIFF
--- a/src/main/java/com/hanghae/baedalfriend/domain/Member.java
+++ b/src/main/java/com/hanghae/baedalfriend/domain/Member.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Where(clause = "is_deleted = false")
-@SQLDelete(sql = "UPDATE member SET is_deleted = true where id = ?")
 public class Member extends Timestamped implements Serializable{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,10 +41,6 @@ public class Member extends Timestamped implements Serializable{
 
     @Enumerated(value = EnumType.STRING)
     private Authority role;
-
-    @JsonIgnore
-    @Builder.Default
-    private boolean isDeleted = Boolean.FALSE;
 
     public Member(String encodedPassword, String profileURL, String nickname, Long kakaoId) {
         this.nickname = nickname;

--- a/src/main/java/com/hanghae/baedalfriend/service/MypageService.java
+++ b/src/main/java/com/hanghae/baedalfriend/service/MypageService.java
@@ -185,9 +185,7 @@ public class MypageService {
             String fileName = member.getProfileURL();
             s3Service.deleteImage(fileName);
         }
-
         memberRepository.deleteById(memberId);
-        SecurityContextHolder.clearContext();
 
         return ResponseDto.success("회원 탈퇴 완료");
     }


### PR DESCRIPTION
### PR 타입
기능 수정

### 반영 브랜치
feature/mypage -> dev

### 변경 사항
회원 탈퇴 기능을 soft delete  -> hard delete

시도해 보다가 테스트 중에 탈퇴가 된 이메일로 다시 회원가입이 되는 이슈가 있었습니다
그것을 그냥 db를 지우는 방식으로 바꾸기로 했습니다