### PR TITLE
Fix: 회원탈퇴 부분 채팅 참가자와 미참가자 구분 안되는 것 고침

### DIFF
--- a/src/main/java/com/hanghae/baedalfriend/chat/repository/ChatRoomMemberJpaRepository.java
+++ b/src/main/java/com/hanghae/baedalfriend/chat/repository/ChatRoomMemberJpaRepository.java
@@ -20,5 +20,7 @@ public interface ChatRoomMemberJpaRepository extends JpaRepository<ChatRoomMembe
 
     List<ChatRoomMember> findAllByMemberId(Long memberId);
 
+    ChatRoomMember findByMemberId(Long memberId);
+
     void deleteByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/hanghae/baedalfriend/service/MypageService.java
+++ b/src/main/java/com/hanghae/baedalfriend/service/MypageService.java
@@ -175,10 +175,10 @@ public class MypageService {
         );
         Post post = postRepository.findByMemberId(memberId);
         ChatRoom chatRoom = chatRoomJpaRepository.findAllByPost(post);
+        ChatRoomMember chatRoomMember = chatRoomMemberJpaRepository.findByMemberId(memberId);
         List<ChatRoomMember> chatRoomMembers = chatRoomMemberJpaRepository.findAllByMemberId(memberId);
 
-
-        if (post == null && chatRoom != null) { //채팅 참가자
+        if (post == null && chatRoomMember != null){//채팅 참가자
             if (!chatRoomMembers.get(0).getChatRoom().getPost().isClosed() || !chatRoomMembers.get(0).getChatRoom().getPost().isDone()) {
                 return ResponseDto.fail("No_Admittance", "진행중인 배프가 있습니다");
             }


### PR DESCRIPTION
### PR 타입
기능 수정

### 반영 브랜치
feature/mypage -> dev

### 변경 사항
공구 미참가자의 탈퇴가 되지않았던 이슈를 고치고 테스트를 하던 와중에 참가자도 삭제가 되는 이슈를 발견했습니다
코드를 추가하여 참가자를 확인하는 부분을 추가 + 수정 했습니다