### PR TITLE
Fix: 이미지 프로필 변경시 이름이 길 경우 잘못된 형식입니다라는 에러가 뜨는 오류

### DIFF
--- a/src/main/java/com/hanghae/baedalfriend/service/S3Service.java
+++ b/src/main/java/com/hanghae/baedalfriend/service/S3Service.java
@@ -78,9 +78,10 @@ public class S3Service {
         return amazonS3.getUrl(bucket, fileName).toString();
     }
     private String createFileName(String fileName) { // 먼저 파일 업로드 시, 파일명을 난수화하기 위해 random으로 돌립니다.
-        // 파일 이름의 길이가 길면 100자로 자르기 (디비의 varchar(255) 제한에 걸리지 않으려고)
+        // 파일 이름의 길이가 길면 50자로 자르기
         if (fileName.length()>100){
-            fileName = fileName.substring(0,100);
+            String filename = fileName.substring(50);
+            return UUID.randomUUID().toString().concat(getFileExtension(filename));
         }
         return UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }


### PR DESCRIPTION
### PR 타입
(피드백)오류 수정

### 반영 브랜치
feature/S3 -> dev

### 변경 사항
유저 피드백 중 프로필 이미지가 변경이 안됀다 하셨는데 그것이 이름이 길 경우 확장자를 찾지 못해 발생하는 오류로 발견 되어 수정했습니다